### PR TITLE
Fix empty search results when YouTube serves "Suggested Product" ads (issue #21)

### DIFF
--- a/youtube_search/__init__.py
+++ b/youtube_search/__init__.py
@@ -32,24 +32,24 @@ class YoutubeSearch:
         json_str = response[start:end]
         data = json.loads(json_str)
 
-        videos = data["contents"]["twoColumnSearchResultsRenderer"]["primaryContents"][
-            "sectionListRenderer"
-        ]["contents"][0]["itemSectionRenderer"]["contents"]
+        for contents in data["contents"]["twoColumnSearchResultsRenderer"]["primaryContents"]["sectionListRenderer"]["contents"]:
+            for video in contents["itemSectionRenderer"]["contents"]:
+                res = {}
+                if "videoRenderer" in video.keys():
+                    video_data = video.get("videoRenderer", {})
+                    res["id"] = video_data.get("videoId", None)
+                    res["thumbnails"] = [thumb.get("url", None) for thumb in video_data.get("thumbnail", {}).get("thumbnails", [{}]) ]
+                    res["title"] = video_data.get("title", {}).get("runs", [[{}]])[0].get("text", None)
+                    res["long_desc"] = video_data.get("descriptionSnippet", {}).get("runs", [{}])[0].get("text", None)
+                    res["channel"] = video_data.get("longBylineText", {}).get("runs", [[{}]])[0].get("text", None)
+                    res["duration"] = video_data.get("lengthText", {}).get("simpleText", 0)
+                    res["views"] = video_data.get("viewCountText", {}).get("simpleText", 0)
+                    res["publish_time"] = video_data.get("publishedTimeText", {}).get("simpleText", 0)
+                    res["url_suffix"] = video_data.get("navigationEndpoint", {}).get("commandMetadata", {}).get("webCommandMetadata", {}).get("url", None)
+                    results.append(res)
 
-        for video in videos:
-            res = {}
-            if "videoRenderer" in video.keys():
-                video_data = video.get("videoRenderer", {})
-                res["id"] = video_data.get("videoId", None)
-                res["thumbnails"] = [thumb.get("url", None) for thumb in video_data.get("thumbnail", {}).get("thumbnails", [{}]) ]
-                res["title"] = video_data.get("title", {}).get("runs", [[{}]])[0].get("text", None)
-                res["long_desc"] = video_data.get("descriptionSnippet", {}).get("runs", [{}])[0].get("text", None)
-                res["channel"] = video_data.get("longBylineText", {}).get("runs", [[{}]])[0].get("text", None)
-                res["duration"] = video_data.get("lengthText", {}).get("simpleText", 0)
-                res["views"] = video_data.get("viewCountText", {}).get("simpleText", 0)
-                res["publish_time"] = video_data.get("publishedTimeText", {}).get("simpleText", 0)
-                res["url_suffix"] = video_data.get("navigationEndpoint", {}).get("commandMetadata", {}).get("webCommandMetadata", {}).get("url", None)
-                results.append(res)
+            if results:
+                return results
         return results
 
     def to_dict(self, clear_cache=True):


### PR DESCRIPTION
As demonstrated in issue #21, some search queries return empty lists because YouTube serves "Suggested Product" adverts on these queries.

The issue was here:
https://github.com/joetats/youtube_search/blob/886fe1b16c829215ee0984b6859f874b4a30d875/youtube_search/__init__.py#L35-L37
When the adverts were served, the first few items of `data["contents"]["twoColumnSearchResultsRenderer"]["primaryContents"]["sectionListRenderer"]["contents"]` just contain the adverts and not any valid videos.

This PR fixes this issue by looping over all items in this list and returning `results` only once it contains some actual results.